### PR TITLE
Add Nix support to language tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -557,6 +557,10 @@ jobs:
         run: make clean bun
         working-directory: ./test/language
 
+      - name: test/language Nix
+        run: make clean nix
+        working-directory: ./test/language
+
       - name: test/compile_package0
         run: make
         working-directory: ./test/compile_package0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -527,6 +527,9 @@ jobs:
           elixir-version: "1.16.1"
           rebar3-version: "3"
 
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v27
+
       - name: Download Glistix binary from previous job
         uses: actions/download-artifact@v4
         with:

--- a/test/language/Makefile
+++ b/test/language/Makefile
@@ -24,3 +24,8 @@ deno:
 bun:
 	@echo test/languate on JavaScript with Bun
 	cargo run --quiet -- test --target javascript --runtime bun
+
+.phony: nix
+nix:
+	@echo test/language on Nix
+	cargo run --quiet -- test --target nix

--- a/test/language/test/ffi.gleam
+++ b/test/language/test/ffi.gleam
@@ -2,24 +2,30 @@ pub type Dynamic
 
 @external(erlang, "ffi_erlang", "print")
 @external(javascript, "./ffi_javascript.mjs", "print")
+@external(nix, "./ffi_nix.nix", "print")
 pub fn print(a: String) -> Nil
 
 @external(erlang, "ffi_erlang", "append")
 @external(javascript, "./ffi_javascript.mjs", "append")
+@external(nix, "./ffi_nix.nix", "append")
 pub fn append(a: String, b: String) -> String
 
 @external(erlang, "ffi_erlang", "to_string")
 @external(javascript, "./ffi_javascript.mjs", "toString")
+@external(nix, "./ffi_nix.nix", "toString")
 pub fn to_string(a: anything) -> String
 
 @external(erlang, "ffi_erlang", "file_exists")
 @external(javascript, "./ffi_javascript.mjs", "fileExists")
+@external(nix, "./ffi_nix.nix", "fileExists")
 pub fn file_exists(a: String) -> Bool
 
 @external(erlang, "ffi_erlang", "halt")
 @external(javascript, "./ffi_javascript.mjs", "halt")
+@external(nix, "./ffi_nix.nix", "halt")
 pub fn halt(a: Int) -> Nil
 
 @external(erlang, "ffi_erlang", "to_dynamic")
 @external(javascript, "./ffi_javascript.mjs", "toDynamic")
+@external(nix, "./ffi_nix.nix", "toDynamic")
 pub fn to_dynamic(a: x) -> Dynamic

--- a/test/language/test/ffi_nix.nix
+++ b/test/language/test/ffi_nix.nix
@@ -6,7 +6,7 @@ let
     f:
         let
             # ./. is relative to this file in the build directory (language/build/dev/nix/ffi_nix.nix)
-            # In other targets, this would be relative to 'language/', so let's go back there'
+            # In other targets, this would be relative to 'language/', so let's go back there
             absPath = if builtins.isString f && builtins.substring 0 1 f != "/" then ./../../../../${f} else f;
         in builtins.pathExists absPath;
   halt = code: if code == 0 then null else builtins.abort (toString code);

--- a/test/language/test/ffi_nix.nix
+++ b/test/language/test/ffi_nix.nix
@@ -1,0 +1,15 @@
+let
+  print = msg: builtins.trace msg null;
+  append = a: b: a + b;
+  toString = builtins.toJSON;
+  fileExists =
+    f:
+        let
+            # ./. is relative to this file in the build directory (language/build/dev/nix/ffi_nix.nix)
+            # In other targets, this would be relative to 'language/', so let's go back there'
+            absPath = if builtins.isString f && builtins.substring 0 1 f != "/" then ./../../../../${f} else f;
+        in builtins.pathExists absPath;
+  halt = code: if code == 0 then null else builtins.abort (toString code);
+  toDynamic = x: x;
+in
+{ inherit print append toString fileExists halt toDynamic; }

--- a/test/language/test/importable.gleam
+++ b/test/language/test/importable.gleam
@@ -16,6 +16,7 @@ pub const ints_in_bit_array = <<1, 2, 3>>
 
 pub const string_in_bit_array = <<"Gleam":utf8>>
 
+@target(erlang)
 pub const data = <<
   0x1,
   2,
@@ -26,6 +27,28 @@ pub const data = <<
   <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
 >>
 
+@target(javascript)
+pub const data = <<
+  0x1,
+  2,
+  2:size(16),
+  0x4:size(32),
+  "Gleam":utf8,
+  4.2:float,
+  <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
+>>
+
+@target(nix)
+pub const data = <<
+  0x1,
+  2,
+  2:size(16),
+  0x4:size(32),
+  "Gleam":utf8,
+  <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
+>>
+
+@target(erlang)
 pub fn get_bit_array() {
   <<
     0x1,
@@ -34,6 +57,32 @@ pub fn get_bit_array() {
     0x4:size(32),
     "Gleam":utf8,
     4.2:float,
+    <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
+  >>
+}
+
+@target(javascript)
+pub fn get_bit_array() {
+  <<
+    0x1,
+    2,
+    2:size(16),
+    0x4:size(32),
+    "Gleam":utf8,
+    4.2:float,
+    <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
+  >>
+}
+
+// TODO: impl :float on nix
+@target(nix)
+pub fn get_bit_array() {
+  <<
+    0x1,
+    2,
+    2:size(16),
+    0x4:size(32),
+    "Gleam":utf8,
     <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
   >>
 }

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -242,10 +242,50 @@ fn assert_tests() -> List(Test) {
   ]
 }
 
+@target(erlang)
 fn tail_call_optimisation_tests() -> List(Test) {
   [
     "10 million recursions doesn't overflow the stack"
     |> example(fn() { assert_equal(Nil, count_down(from: 10_000_000)) }),
+    // https://github.com/gleam-lang/gleam/issues/1214
+    // https://github.com/gleam-lang/gleam/issues/1380
+    "Arguments correctly reassigned"
+    |> example(fn() {
+      assert_equal([1, 2, 3], tail_recursive_accumulate_down(3, []))
+    }),
+    // https://github.com/gleam-lang/gleam/issues/2400
+    "not recursion, the function is shadowed its argument"
+    |> example(fn() {
+      assert_equal(function_shadowed_by_own_argument(fn() { 1 }), 1)
+    }),
+  ]
+}
+
+@target(javascript)
+fn tail_call_optimisation_tests() -> List(Test) {
+  [
+    "10 million recursions doesn't overflow the stack"
+    |> example(fn() { assert_equal(Nil, count_down(from: 10_000_000)) }),
+    // https://github.com/gleam-lang/gleam/issues/1214
+    // https://github.com/gleam-lang/gleam/issues/1380
+    "Arguments correctly reassigned"
+    |> example(fn() {
+      assert_equal([1, 2, 3], tail_recursive_accumulate_down(3, []))
+    }),
+    // https://github.com/gleam-lang/gleam/issues/2400
+    "not recursion, the function is shadowed its argument"
+    |> example(fn() {
+      assert_equal(function_shadowed_by_own_argument(fn() { 1 }), 1)
+    }),
+  ]
+}
+
+@target(nix)
+fn tail_call_optimisation_tests() -> List(Test) {
+  [
+    // TODO: Tail call optimization
+    // "10 million recursions doesn't overflow the stack"
+    // |> example(fn() { assert_equal(Nil, count_down(from: 10_000_000)) }),
     // https://github.com/gleam-lang/gleam/issues/1214
     // https://github.com/gleam-lang/gleam/issues/1380
     "Arguments correctly reassigned"
@@ -951,6 +991,7 @@ fn equality_tests() -> List(Test) {
   ]
 }
 
+@target(erlang)
 fn bit_array_tests() -> List(Test) {
   [
     "<<\"Gleam\":utf8, \"👍\":utf8>> == <<\"Gleam\":utf8, \"👍\":utf8>>"
@@ -977,6 +1018,57 @@ fn bit_array_tests() -> List(Test) {
   ]
 }
 
+@target(javascript)
+fn bit_array_tests() -> List(Test) {
+  [
+    "<<\"Gleam\":utf8, \"👍\":utf8>> == <<\"Gleam\":utf8, \"👍\":utf8>>"
+    |> example(fn() {
+      assert_equal(
+        True,
+        <<"Gleam":utf8, "👍":utf8>> == <<"Gleam":utf8, "👍":utf8>>,
+      )
+    }),
+    "<<\"Gleam\":utf8, \"👍\":utf8>> == <<\"👍\":utf8>>"
+    |> example(fn() {
+      assert_equal(False, <<"Gleam":utf8, "👍":utf8>> == <<"👍":utf8>>)
+    }),
+    "<<\"abc\":utf8>> == <<97, 98, 99>>"
+    |> example(fn() { assert_equal(True, <<"abc":utf8>> == <<97, 98, 99>>) }),
+    "<<<<1>>:bit_array, 2>> == <<1, 2>>"
+    |> example(fn() { assert_equal(True, <<<<1>>:bits, 2>> == <<1, 2>>) }),
+    "<<1>> == <<1:int>>"
+    |> example(fn() { assert_equal(True, <<1>> == <<1:int>>) }),
+    "<<63, 240, 0, 0, 0, 0, 0, 0>> == <<1.0:float>>"
+    |> example(fn() {
+      assert_equal(True, <<63, 240, 0, 0, 0, 0, 0, 0>> == <<1.0:float>>)
+    }),
+  ]
+}
+
+// TODO: impl :float on nix
+@target(nix)
+fn bit_array_tests() -> List(Test) {
+  [
+    "<<\"Gleam\":utf8, \"👍\":utf8>> == <<\"Gleam\":utf8, \"👍\":utf8>>"
+    |> example(fn() {
+      assert_equal(
+        True,
+        <<"Gleam":utf8, "👍":utf8>> == <<"Gleam":utf8, "👍":utf8>>,
+      )
+    }),
+    "<<\"Gleam\":utf8, \"👍\":utf8>> == <<\"👍\":utf8>>"
+    |> example(fn() {
+      assert_equal(False, <<"Gleam":utf8, "👍":utf8>> == <<"👍":utf8>>)
+    }),
+    "<<\"abc\":utf8>> == <<97, 98, 99>>"
+    |> example(fn() { assert_equal(True, <<"abc":utf8>> == <<97, 98, 99>>) }),
+    "<<<<1>>:bit_array, 2>> == <<1, 2>>"
+    |> example(fn() { assert_equal(True, <<<<1>>:bits, 2>> == <<1, 2>>) }),
+    "<<1>> == <<1:int>>"
+    |> example(fn() { assert_equal(True, <<1>> == <<1:int>>) }),
+  ]
+}
+
 @target(erlang)
 fn bit_array_target_tests() -> List(Test) {
   [
@@ -992,6 +1084,11 @@ fn bit_array_target_tests() -> List(Test) {
 }
 
 @target(javascript)
+fn bit_array_target_tests() -> List(Test) {
+  []
+}
+
+@target(nix)
 fn bit_array_target_tests() -> List(Test) {
   []
 }
@@ -1319,6 +1416,7 @@ fn int_negation_tests() {
   ]
 }
 
+@target(erlang)
 fn bit_array_match_tests() {
   [
     "let <<1, x>> = <<1, 2>>"
@@ -1403,6 +1501,190 @@ fn bit_array_match_tests() {
           0x4:size(32),
           "Gleam":utf8,
           4.2:float,
+          <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
+        >> == importable.data,
+      )
+    }),
+    "<<71, 108, 101, 97, 109>> == <<\"Gleam\":utf8>>"
+    |> example(fn() {
+      assert_equal(True, <<71, 108, 101, 97, 109>> == <<"Gleam":utf8>>)
+    }),
+  ]
+}
+
+@target(javascript)
+fn bit_array_match_tests() {
+  [
+    "let <<1, x>> = <<1, 2>>"
+    |> example(fn() {
+      assert_equal(2, {
+        let assert <<1, x>> = <<1, 2>>
+        x
+      })
+    }),
+    "let <<a:8>> = <<1>>"
+    |> example(fn() {
+      assert_equal(1, {
+        let assert <<a:8>> = <<1>>
+        a
+      })
+    }),
+    "let <<a:16, b:8>> = <<1, 2, 3>>"
+    |> example(fn() {
+      assert_equal(#(258, 3), {
+        let assert <<a:16, b:8>> = <<1, 2, 3>>
+        #(a, b)
+      })
+    }),
+    "let <<a:float, b:int>> = <<63,240,0,0,0,0,0,0,1>>"
+    |> example(fn() {
+      assert_equal(#(1.0, 1), {
+        let assert <<a:float, b:int>> = <<63, 240, 0, 0, 0, 0, 0, 0, 1>>
+        #(a, b)
+      })
+    }),
+    "let <<a:float>> = <<1.23:float>>"
+    |> example(fn() {
+      assert_equal(1.23, {
+        let assert <<a:float>> = <<1.23:float>>
+        a
+      })
+    }),
+    "let <<_, rest:binary>> = <<1>>"
+    |> example(fn() {
+      assert_equal(<<>>, {
+        let assert <<_, rest:bytes>> = <<1>>
+        rest
+      })
+    }),
+    "let <<_, rest:binary>> = <<1,2,3>>"
+    |> example(fn() {
+      assert_equal(<<2, 3>>, {
+        let assert <<_, rest:bytes>> = <<1, 2, 3>>
+        rest
+      })
+    }),
+    "let <<x:2-binary, rest:binary>> = <<1,2,3>>"
+    |> example(fn() {
+      assert_equal(<<1, 2>>, {
+        let assert <<x:2-bytes, _:bytes>> = <<1, 2, 3>>
+        x
+      })
+    }),
+    "bit_array from function"
+    |> example(fn() {
+      assert_equal(
+        True,
+        <<
+          0x1,
+          2,
+          2:size(16),
+          0x4:size(32),
+          "Gleam":utf8,
+          4.2:float,
+          <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
+        >> == importable.get_bit_array(),
+      )
+    }),
+    "bit_array module const"
+    |> example(fn() {
+      assert_equal(
+        True,
+        <<
+          0x1,
+          2,
+          2:size(16),
+          0x4:size(32),
+          "Gleam":utf8,
+          4.2:float,
+          <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
+        >> == importable.data,
+      )
+    }),
+    "<<71, 108, 101, 97, 109>> == <<\"Gleam\":utf8>>"
+    |> example(fn() {
+      assert_equal(True, <<71, 108, 101, 97, 109>> == <<"Gleam":utf8>>)
+    }),
+  ]
+}
+
+// TODO: impl :float on bitarrays so we can keep one test for all targets
+@target(nix)
+fn bit_array_match_tests() {
+  [
+    "let <<1, x>> = <<1, 2>>"
+    |> example(fn() {
+      assert_equal(2, {
+        let assert <<1, x>> = <<1, 2>>
+        x
+      })
+    }),
+    "let <<a:8>> = <<1>>"
+    |> example(fn() {
+      assert_equal(1, {
+        let assert <<a:8>> = <<1>>
+        a
+      })
+    }),
+    "let <<a:16, b:8>> = <<1, 2, 3>>"
+    |> example(fn() {
+      assert_equal(#(258, 3), {
+        let assert <<a:16, b:8>> = <<1, 2, 3>>
+        #(a, b)
+      })
+    }),
+    "let <<b:int>> = <<1>>"
+    |> example(fn() {
+      assert_equal(1, {
+        let assert <<b:int>> = <<1>>
+        b
+      })
+    }),
+    "let <<_, rest:binary>> = <<1>>"
+    |> example(fn() {
+      assert_equal(<<>>, {
+        let assert <<_, rest:bytes>> = <<1>>
+        rest
+      })
+    }),
+    "let <<_, rest:binary>> = <<1,2,3>>"
+    |> example(fn() {
+      assert_equal(<<2, 3>>, {
+        let assert <<_, rest:bytes>> = <<1, 2, 3>>
+        rest
+      })
+    }),
+    "let <<x:2-binary, rest:binary>> = <<1,2,3>>"
+    |> example(fn() {
+      assert_equal(<<1, 2>>, {
+        let assert <<x:2-bytes, _:bytes>> = <<1, 2, 3>>
+        x
+      })
+    }),
+    "bit_array from function"
+    |> example(fn() {
+      assert_equal(
+        True,
+        <<
+          0x1,
+          2,
+          2:size(16),
+          0x4:size(32),
+          "Gleam":utf8,
+          <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
+        >> == importable.get_bit_array(),
+      )
+    }),
+    "bit_array module const"
+    |> example(fn() {
+      assert_equal(
+        True,
+        <<
+          0x1,
+          2,
+          2:size(16),
+          0x4:size(32),
+          "Gleam":utf8,
           <<<<1, 2, 3>>:bits, "Gleam":utf8, 1024>>:bits,
         >> == importable.data,
       )
@@ -1499,6 +1781,16 @@ fn typescript_file_included_tests() {
 @target(erlang)
 fn typescript_file_included_tests() {
   let path = "./build/dev/erlang/language/_gleam_artefacts/ffi_typescript.ts"
+  [
+    path
+    |> example(fn() { assert_equal(file_exists(path), True) }),
+  ]
+}
+
+@target(nix)
+fn typescript_file_included_tests() {
+  // Relative to current file
+  let path = "./build/dev/nix/language/ffi_typescript.ts"
   [
     path
     |> example(fn() { assert_equal(file_exists(path), True) }),

--- a/test/language/test/language_test.gleam
+++ b/test/language/test/language_test.gleam
@@ -1789,7 +1789,6 @@ fn typescript_file_included_tests() {
 
 @target(nix)
 fn typescript_file_included_tests() {
-  // Relative to current file
   let path = "./build/dev/nix/language/ffi_typescript.ts"
   [
     path


### PR DESCRIPTION
- Adds Nix FFI
- Removes `:float` from bit array tests due to #9
- Removes tail-call optimization tests
- Adds missing per-target functions

TODO:
- [x] Ensure this runs on CI