### PR TITLE
Port Gleam 1.3 JS fixes to Nix

### DIFF
--- a/compiler-core/src/codegen.rs
+++ b/compiler-core/src/codegen.rs
@@ -282,7 +282,13 @@ impl<'a> Nix<'a> {
             "builtins.import {}\n",
             nix::syntax::path(self.prelude_location.as_str())
         );
-        writer.write(&self.output_directory.join("gleam.nix"), &rexport)?;
+        let prelude_path = &self.output_directory.join("gleam.nix");
+
+        // This check skips unnecessary `gleam.nix` writes which confuse
+        // watchers
+        if !writer.exists(prelude_path) {
+            writer.write(prelude_path, &rexport)?;
+        }
 
         Ok(())
     }

--- a/compiler-core/src/nix/expression.rs
+++ b/compiler-core/src/nix/expression.rs
@@ -1299,10 +1299,11 @@ pub(crate) fn constant_expression<'a>(
         Constant::Record { typ, .. } if typ.is_nil() => Ok("null".to_doc()),
 
         Constant::Record {
-            tag,
-            typ,
             args,
             module,
+            name,
+            tag,
+            typ,
             ..
         } => {
             if typ.is_result() {
@@ -1317,7 +1318,7 @@ pub(crate) fn constant_expression<'a>(
                 .map(|arg| wrap_child_constant_expression(tracker, &arg.value))
                 .try_collect()?;
 
-            Ok(construct_record(module.as_deref(), tag, field_values))
+            Ok(construct_record(module.as_deref(), name, field_values))
         }
 
         Constant::BitArray { segments, .. } => {

--- a/compiler-core/src/nix/tests.rs
+++ b/compiler-core/src/nix/tests.rs
@@ -17,6 +17,7 @@ mod blocks;
 mod bools;
 mod case;
 mod case_clause_guards;
+mod consts;
 mod custom_types;
 mod externals;
 mod functions;

--- a/compiler-core/src/nix/tests/bit_arrays.rs
+++ b/compiler-core/src/nix/tests/bit_arrays.rs
@@ -60,7 +60,7 @@ fn sized() {
     assert_nix!(
         r#"
 fn go() {
-  <<256:4>>
+  <<256:64>>
 }
 "#,
     );
@@ -71,7 +71,7 @@ fn explicit_sized() {
     assert_nix!(
         r#"
 fn go() {
-  <<256:size(4)>>
+  <<256:size(64)>>
 }
 "#,
     );
@@ -244,4 +244,56 @@ fn as_module_const() {
           >>
         "#
     )
+}
+
+#[test]
+fn negative_size() {
+    assert_nix!(
+        r#"
+fn go() {
+  <<1:size(-1)>>
+}
+"#,
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/1591
+#[test]
+fn not_byte_aligned() {
+    assert_nix!(
+        r#"
+fn thing() {
+  4
+}
+fn go() {
+  <<256:4>>
+}
+"#,
+    );
+}
+
+#[test]
+fn not_byte_aligned_explicit_sized() {
+    assert_nix!(
+        r#"
+fn go() {
+  <<256:size(4)>>
+}
+"#,
+    );
+}
+
+// This test would ideally also result in go() being deleted like the previous tests
+// but we can not know for sure what the value of a variable is going to be
+// so right now go() is not deleted.
+#[test]
+fn not_byte_aligned_variable() {
+    assert_nix!(
+        r#"
+fn go() {
+  let x = 4
+  <<256:size(x)>>
+}
+"#,
+    );
 }

--- a/compiler-core/src/nix/tests/case.rs
+++ b/compiler-core/src/nix/tests/case.rs
@@ -253,3 +253,37 @@ pub fn main() {
 "#
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/3379
+#[test]
+fn single_clause_variables() {
+    assert_nix!(
+        r#"
+pub fn main() {
+  let text = "first defined"
+  case "defined again" {
+    text -> Nil
+  }
+  let text = "a third time"
+  Nil
+}
+"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/3379
+#[test]
+fn single_clause_variables_assigned() {
+    assert_nix!(
+        r#"
+pub fn main() {
+  let text = "first defined"
+  let other = case "defined again" {
+    text -> Nil
+  }
+  let text = "a third time"
+  Nil
+}
+"#
+    )
+}

--- a/compiler-core/src/nix/tests/consts.rs
+++ b/compiler-core/src/nix/tests/consts.rs
@@ -1,0 +1,35 @@
+use crate::assert_nix;
+
+#[test]
+fn custom_type_constructor_imported_and_aliased() {
+    assert_nix!(
+        ("package", "other_module", "pub type T { A }"),
+        r#"import other_module.{A as B}
+pub const local = B
+"#,
+    );
+}
+
+#[test]
+fn imported_aliased_ok() {
+    assert_nix!(
+        r#"import gleam.{Ok as Y}
+pub type X {
+  Ok
+}
+pub const y = Y
+"#,
+    );
+}
+
+#[test]
+fn imported_ok() {
+    assert_nix!(
+        r#"import gleam
+pub type X {
+  Ok
+}
+pub const y = gleam.Ok
+"#,
+    );
+}

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__negative_size.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__negative_size.snap
@@ -1,10 +1,10 @@
 ---
 source: compiler-core/src/nix/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:size(64)>>\n}\n"
+expression: "\nfn go() {\n  <<1:size(-1)>>\n}\n"
 ---
 let
   inherit (builtins.import ./../gleam.nix) toBitArray sizedInt;
   
-  go = { }: toBitArray [ (sizedInt 256 64) ];
+  go = { }: toBitArray [ (sizedInt 1 (-1)) ];
 in
 { }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__not_byte_aligned.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__not_byte_aligned.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/nix/tests/bit_arrays.rs
+expression: "\nfn thing() {\n  4\n}\nfn go() {\n  <<256:4>>\n}\n"
+---
+let inherit (builtins.import ./../gleam.nix) toBitArray; thing = { }: 4; in { }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__not_byte_aligned_explicit_sized.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__not_byte_aligned_explicit_sized.snap
@@ -1,0 +1,5 @@
+---
+source: compiler-core/src/nix/tests/bit_arrays.rs
+expression: "\nfn go() {\n  <<256:size(4)>>\n}\n"
+---
+let inherit (builtins.import ./../gleam.nix) toBitArray; in { }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__not_byte_aligned_variable.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__not_byte_aligned_variable.snap
@@ -1,10 +1,10 @@
 ---
 source: compiler-core/src/nix/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:size(64)>>\n}\n"
+expression: "\nfn go() {\n  let x = 4\n  <<256:size(x)>>\n}\n"
 ---
 let
   inherit (builtins.import ./../gleam.nix) toBitArray sizedInt;
   
-  go = { }: toBitArray [ (sizedInt 256 64) ];
+  go = { }: let x = 4; in toBitArray [ (sizedInt 256 x) ];
 in
 { }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__sized.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__bit_arrays__sized.snap
@@ -1,10 +1,10 @@
 ---
 source: compiler-core/src/nix/tests/bit_arrays.rs
-expression: "\nfn go() {\n  <<256:4>>\n}\n"
+expression: "\nfn go() {\n  <<256:64>>\n}\n"
 ---
 let
   inherit (builtins.import ./../gleam.nix) toBitArray sizedInt;
   
-  go = { }: toBitArray [ (sizedInt 256 4) ];
+  go = { }: toBitArray [ (sizedInt 256 64) ];
 in
 { }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__case__single_clause_variables.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__case__single_clause_variables.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/nix/tests/case.rs
+expression: "\npub fn main() {\n  let text = \"first defined\"\n  case \"defined again\" {\n    text -> Nil\n  }\n  let text = \"a third time\"\n  Nil\n}\n"
+---
+let
+  main =
+    { }:
+    let
+      text = "first defined";
+      _' = let _pat' = "defined again"; in let text'1 = _pat'; in null;
+      text'1 = "a third time";
+    in
+    builtins.seq _' null;
+in
+{ inherit main; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__case__single_clause_variables_assigned.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__case__single_clause_variables_assigned.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/nix/tests/case.rs
+expression: "\npub fn main() {\n  let text = \"first defined\"\n  let other = case \"defined again\" {\n    text -> Nil\n  }\n  let text = \"a third time\"\n  Nil\n}\n"
+---
+let
+  main =
+    { }:
+    let
+      text = "first defined";
+      other = let _pat' = "defined again"; in let text'1 = _pat'; in null;
+      text'1 = "a third time";
+    in
+    null;
+in
+{ inherit main; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__consts__custom_type_constructor_imported_and_aliased.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__consts__custom_type_constructor_imported_and_aliased.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/nix/tests/consts.rs
+expression: "import other_module.{A as B}\npub const local = B\n"
+---
+let
+  other_module' = builtins.import ./../../package/other_module.nix;
+  B = (builtins.import ./../../package/other_module.nix).A;
+  
+  local = B;
+in
+{ inherit local; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__consts__imported_aliased_ok.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__consts__imported_aliased_ok.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/nix/tests/consts.rs
+expression: "import gleam.{Ok as Y}\npub type X {\n  Ok\n}\npub const y = Y\n"
+---
+let
+  gleam' = builtins.import ./../gleam.nix;
+  Y = (builtins.import ./../gleam.nix).Ok;
+  
+  Ok = { __gleamTag = "Ok"; };
+  
+  y = Y;
+in
+{ inherit Ok y; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__consts__imported_ok.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__consts__imported_ok.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/nix/tests/consts.rs
+expression: "import gleam\npub type X {\n  Ok\n}\npub const y = gleam.Ok\n"
+---
+let
+  gleam' = builtins.import ./../gleam.nix;
+  
+  Ok = { __gleamTag = "Ok"; };
+  
+  y = gleam'.Ok;
+in
+{ inherit Ok y; }


### PR DESCRIPTION
Ports the following JS target fixes to Nix:

1. Adds bit array byte-alignment compile-time checks (https://github.com/gleam-lang/gleam/pull/3111)
2. Do not unnecessarily rewrite `gleam.nix` in the build output (from the fix to https://github.com/gleam-lang/gleam/issues/3178 at https://github.com/gleam-lang/gleam/commit/975536533e26d9afb8b94f785a0b7aecc637f733)
3. Fix using aliased record constructors in constants (from the fix for https://github.com/gleam-lang/gleam/issues/3294 at https://github.com/gleam-lang/gleam/commit/ec614e7746de3e31b6edf16dadd99d59352bc264)

Also added a test to verify that https://github.com/gleam-lang/gleam/issues/3379 does not apply to the Nix target.