### PR TITLE
Add Nix support to `compiler-wasm`

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -62,7 +62,8 @@ jobs:
       - name: Build archive
         shell: bash
         run: |
-          VERSION="${GITHUB_REF#refs/tags/}"
+          # Get latest version
+          VERSION="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
 
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             ARCHIVE="glistix-$VERSION-${{ matrix.target }}.zip"
@@ -105,7 +106,7 @@ jobs:
           retention-days: 3
 
   build-test-wasm:
-    name: build-release-wasm
+    name: build-test-wasm
     runs-on: ubuntu-latest
 
     steps:
@@ -128,7 +129,8 @@ jobs:
 
       - name: Build wasm archive
         run: |
-          VERSION="${GITHUB_REF#refs/tags/}"
+          # Get latest version
+          VERSION="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
           ARCHIVE="glistix-$VERSION-browser.tar.gz"
 
           tar -C compiler-wasm/pkg/ -czvf $ARCHIVE .

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -112,6 +114,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -65,6 +65,7 @@ jobs:
         shell: bash
         run: |
           # Get latest version
+          # https://stackoverflow.com/a/69708418
           VERSION="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
 
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
@@ -115,7 +116,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -134,6 +135,7 @@ jobs:
       - name: Build wasm archive
         run: |
           # Get latest version
+          # https://stackoverflow.com/a/69708418
           VERSION="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
           ARCHIVE="glistix-$VERSION-browser.tar.gz"
 

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -118,7 +118,8 @@ pub fn compile_package(project_id: usize, target: &str) -> Result<(), String> {
         "js" | "javascript" => Target::JavaScript,
         "nix" => Target::Nix,
         _ => {
-            let msg = format!("Unknown target `{target}`, expected `erlang`, `javascript` or `nix`");
+            let msg =
+                format!("Unknown target `{target}`, expected `erlang`, `javascript` or `nix`");
             return Err(msg);
         }
     };

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -116,8 +116,9 @@ pub fn compile_package(project_id: usize, target: &str) -> Result<(), String> {
     let target = match target.to_lowercase().as_str() {
         "erl" | "erlang" => Target::Erlang,
         "js" | "javascript" => Target::JavaScript,
+        "nix" => Target::Nix,
         _ => {
-            let msg = format!("Unknown target `{target}`, expected `erlang` or `javascript`");
+            let msg = format!("Unknown target `{target}`, expected `erlang`, `javascript` or `nix`");
             return Err(msg);
         }
     };
@@ -147,6 +148,17 @@ pub fn read_compiled_erlang(project_id: usize, module_name: &str) -> Option<Stri
         "/build/_gleam_artefacts/{}.erl",
         module_name.replace('/', "@")
     );
+    fs.read(&Utf8PathBuf::from(path)).ok()
+}
+
+/// Get the compiled Nix output for a given module.
+///
+/// You need to call `compile_package` before calling this function.
+///
+#[wasm_bindgen]
+pub fn read_compiled_nix(project_id: usize, module_name: &str) -> Option<String> {
+    let fs = get_filesystem(project_id);
+    let path = format!("/build/{}.nix", module_name);
     fs.read(&Utf8PathBuf::from(path)).ok()
 }
 


### PR DESCRIPTION
Allows using Glistix in the web.

Prerequisite for the playground idea.