### PR TITLE
Add 'nixpkgs follows' by default to flake generated by 'glistix new'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -412,6 +412,12 @@ jobs:
           cd .test-flake
           nix run -L .. -- new newpkg
 
+      # For efficiency, just fully reuse the already built glistix
+      - name: Remove 'follows nixpkgs' from test project flake
+        run: |
+          sed -i -e 's/inputs\.nixpkgs\.follows = "nixpkgs";//' flake.nix
+        working-directory: ./.test-flake/newpkg
+
       - name: Build generated project without flake
         run: |
           # Build to generate manifest.toml

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -277,7 +277,10 @@ jobs:
     }};
 
     # Pick your Glistix version here.
-    glistix.url = "github:glistix/glistix/v0.4.0";
+    glistix.url = {{
+      url = "github:glistix/glistix/v0.4.0";
+      inputs.nixpkgs.follows = "nixpkgs";
+    }};
 
     # Submodules
     # Add any submodules which you use as dependencies here,

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -277,7 +277,7 @@ jobs:
     }};
 
     # Pick your Glistix version here.
-    glistix.url = {{
+    glistix = {{
       url = "github:glistix/glistix/v0.4.0";
       inputs.nixpkgs.follows = "nixpkgs";
     }};


### PR DESCRIPTION
Glistix no longer depends on nixpkgs for its Rust version (it's now pinned), so might as well accept any nixpkgs version.

This helps avoid 'nixpkgs duplication'.