### PR TITLE
Bump to Glistix 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glistix"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base16",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "glistix-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "askama",
  "async-trait",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "glistix-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "camino",
  "console_error_panic_hook",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "test-package-compiler"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "camino",
  "glistix-core",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "test-project-compiler"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "camino",
  "glistix-core",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more information on Gleam, including tutorials, please check [the Gleam lang
 
 **NOTE:** Glistix is **beta software**, and **may have breaking changes**. You shouldn't rely on it on production just yet, but **feel free to give it a shot on personal or smaller projects** and **report any issues and bugs you find**. It should be functional, but we still need people to try it out and report any bugs.
 
-**NOTE:** Glistix's latest stable version currently tracks **Gleam v1.5.1,** meaning features and fixes from up to that Gleam version are available.
+**NOTE:** Glistix's latest stable version currently tracks **Gleam v1.6.3,** meaning features and fixes from up to that Gleam version are available.
 
 **NOTE:** Glistix is **an unofficial project** and is therefore **not affiliated with the Gleam project**.
 
@@ -66,22 +66,22 @@ You can install Glistix in one of the following ways.
 
 1. **From GitHub Releases:** If you're using Linux (any distro, including NixOS), MacOS or Windows, you can install Glistix by downloading the latest precompiled binary for your platform at [https://github.com/glistix/glistix/releases](https://github.com/glistix/glistix/releases).
 
-2. **With Nix flakes:** Invoke the command below in the command line to download, compile and run a specific release of Glistix - here the latest at the time of writing (v0.5.0).
+2. **With Nix flakes:** Invoke the command below in the command line to download, compile and run a specific release of Glistix - here the latest at the time of writing (v0.6.0).
 
     ```sh
-    nix run 'github:Glistix/glistix/v0.5.0' -- --help
+    nix run 'github:Glistix/glistix/v0.6.0' -- --help
     ```
 
-    To install permanently, you can either add `github:Glistix/glistix/v0.5.0` as an input to your system/Home Manager configuration, or use `nix profile`:
+    To install permanently, you can either add `github:Glistix/glistix/v0.6.0` as an input to your system/Home Manager configuration, or use `nix profile`:
 
     ```sh
-    nix profile install 'github:Glistix/glistix/v0.5.0'
+    nix profile install 'github:Glistix/glistix/v0.6.0'
     ```
 
-3. **With Cargo:** You can use Cargo to compile and install Glistix's latest release (v0.5.0 at the time of writing):
+3. **With Cargo:** You can use Cargo to compile and install Glistix's latest release (v0.6.0 at the time of writing):
 
     ```sh
-    cargo install --git https://github.com/glistix/glistix --tag v0.5.0 --locked
+    cargo install --git https://github.com/glistix/glistix --tag v0.6.0 --locked
     ```
 
 ## Table of Contents

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glistix"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["PgBiel"]
 edition = "2021"
 license-file = "LICENCE"

--- a/compiler-cli/src/new.rs
+++ b/compiler-cli/src/new.rs
@@ -286,7 +286,7 @@ jobs:
     }};
 
     # Pick your Glistix version here.
-    glistix.url = "github:glistix/glistix/v0.5.0";
+    glistix.url = "github:glistix/glistix/v0.6.0";
 
     # Submodules
     # Add any submodules which you use as dependencies here,

--- a/compiler-cli/src/new/snapshots/glistix__new__tests__new_with_default_template@flake.nix.snap
+++ b/compiler-cli/src/new/snapshots/glistix__new__tests__new_with_default_template@flake.nix.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-cli/src/new/tests.rs
 expression: "crate::fs::read(Utf8PathBuf::from_path_buf(file_path.to_path_buf()).expect(\"Non Utf8 Path\"),).unwrap()"
-snapshot_kind: text
 ---
 # Make sure to run "nix flake update" at least once to generate your flake.lock.
 # Run your main function from Nix by importing this flake as follows:
@@ -26,7 +25,7 @@ snapshot_kind: text
     };
 
     # Pick your Glistix version here.
-    glistix.url = "github:glistix/glistix/v0.5.0";
+    glistix.url = "github:glistix/glistix/v0.6.0";
 
     # Submodules
     # Add any submodules which you use as dependencies here,

--- a/compiler-cli/src/new/snapshots/glistix__new__tests__new_with_javascript_template@flake.nix.snap
+++ b/compiler-cli/src/new/snapshots/glistix__new__tests__new_with_javascript_template@flake.nix.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-cli/src/new/tests.rs
 expression: "crate::fs::read(Utf8PathBuf::from_path_buf(file_path.to_path_buf()).expect(\"Non Utf8 Path\"),).unwrap()"
-snapshot_kind: text
 ---
 # Make sure to run "nix flake update" at least once to generate your flake.lock.
 # Run your main function from Nix by importing this flake as follows:
@@ -26,7 +25,7 @@ snapshot_kind: text
     };
 
     # Pick your Glistix version here.
-    glistix.url = "github:glistix/glistix/v0.5.0";
+    glistix.url = "github:glistix/glistix/v0.6.0";
 
     # Submodules
     # Add any submodules which you use as dependencies here,

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glistix-core"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["PgBiel"]
 edition = "2021"
 license-file = "LICENCE"

--- a/compiler-wasm/Cargo.toml
+++ b/compiler-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glistix-wasm"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["PgBiel"]
 edition = "2021"
 license-file = "LICENCE"

--- a/nix/glistix.nix
+++ b/nix/glistix.nix
@@ -29,7 +29,7 @@ in
 
 rustPlatform.buildRustPackage {
   pname = "glistix";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = lib.cleanSourceWith {
     filter = filterPaths;
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage {
   buildInputs = [ openssl ] ++
     lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
 
-  cargoHash = "sha256-g7deHhgIUReUEuAc2pk2HMAsGKXkyZrOg0/FArwrlRw=";
+  cargoHash = "sha256-N8OwA+HRYMxzEBY8lfHkQ5zT/XVhNPCkrcwKzUExEXY=";
 
   meta = with lib; {
     description = "A fork of the Gleam compiler with a Nix backend";

--- a/test-package-compiler/Cargo.toml
+++ b/test-package-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-package-compiler"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["PgBiel"]
 edition = "2021"
 license = "Apache-2.0"

--- a/test-project-compiler/Cargo.toml
+++ b/test-project-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-project-compiler"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["PgBiel"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Push a new version with just a Gleam version bump.

If bumping to Gleam 1.7.0 is proven to require an unexpected amount of additional work, we could consider delaying Glistix 0.6.0 and merge dependency patching before that.

Edit: bumping to Gleam 1.7.0 seems fine.