### PR TITLE
Port JS fixes from Gleam 1.7.0 to Nix

### DIFF
--- a/compiler-core/src/build/native_file_copier/tests.rs
+++ b/compiler-core/src/build/native_file_copier/tests.rs
@@ -550,3 +550,25 @@ fn glistix_all_nix_files_are_copied_from_test_subfolders() {
         fs.into_contents(),
     );
 }
+
+#[test]
+fn glistix_conflicting_gleam_and_nix_modules_result_in_an_error() {
+    let fs = InMemoryFileSystem::new();
+    fs.write(&Utf8Path::new("/src/wibble.gleam"), "1").unwrap();
+    fs.write(&Utf8Path::new("/src/wibble.nix"), "1").unwrap();
+
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    assert!(copier.run().is_err());
+}
+
+#[test]
+fn glistix_differently_nested_gleam_and_nix_modules_with_same_name_are_ok() {
+    let fs = InMemoryFileSystem::new();
+    fs.write(&Utf8Path::new("/src/a/b/c/wibble.gleam"), "1")
+        .unwrap();
+    fs.write(&Utf8Path::new("/src/d/e/wibble.nix"), "1")
+        .unwrap();
+
+    let copier = NativeFileCopier::new(fs.clone(), root(), root_out());
+    assert!(copier.run().is_ok());
+}

--- a/compiler-core/src/nix/pattern.rs
+++ b/compiler-core/src/nix/pattern.rs
@@ -553,9 +553,19 @@ impl<'module_ctx, 'expression_gen, 'a> Generator<'module_ctx, 'expression_gen, '
                     // let prefix = "wibble";
                     // ^^^^^^^^^^^^^^^^^^^^^ we're adding this assignment inside the if clause
                     //                       the case branch gets translated into.
-                    let left_side_string =
-                        expression::string(left_side_string, self.expression_generator.tracker);
-                    self.push_assignment(left_side_string, left);
+                    //
+                    // We also want to push this assignment without using push_assignment, since we
+                    // do _not_ want to access the current path on the static string!
+                    let var = self.next_local_var(left);
+                    self.assignments.push(Assignment {
+                        subject: expression::string(
+                            left_side_string,
+                            self.expression_generator.tracker,
+                        ),
+                        path: SubjectPath::new(),
+                        name: left,
+                        var,
+                    });
                 }
                 Ok(())
             }

--- a/compiler-core/src/nix/tests/assignments.rs
+++ b/compiler-core/src/nix/tests/assignments.rs
@@ -180,6 +180,23 @@ pub fn main(x) {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/3894
+#[test]
+fn let_assert_nested_string_prefix() {
+    assert_nix!(
+        r#"
+type Wibble {
+  Wibble(wibble: String)
+}
+
+pub fn main() {
+  let assert Wibble(wibble: "w" as prefix <> rest) = Wibble("wibble")
+  prefix <> rest
+}
+"#
+    );
+}
+
 // Inspired by https://github.com/gleam-lang/gleam/issues/2931
 #[test]
 fn keyword_assignment() {

--- a/compiler-core/src/nix/tests/assignments.rs
+++ b/compiler-core/src/nix/tests/assignments.rs
@@ -180,6 +180,31 @@ pub fn main(x) {
     );
 }
 
+// Inspired by https://github.com/gleam-lang/gleam/issues/2931
+#[test]
+fn keyword_assignment() {
+    assert_nix!(
+        r#"
+pub fn main() {
+  let with = 10
+  let in = 50
+  in
+}
+"#
+    );
+}
+
+// Inspired by https://github.com/gleam-lang/gleam/issues/3004
+#[test]
+fn escaped_variables_in_constants() {
+    assert_nix!(
+        r#"
+pub const with = 5
+pub const in = with
+"#
+    );
+}
+
 #[test]
 fn message() {
     assert_nix!(

--- a/compiler-core/src/nix/tests/case.rs
+++ b/compiler-core/src/nix/tests/case.rs
@@ -287,3 +287,48 @@ pub fn main() {
 "#
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/3894
+#[test]
+fn nested_string_prefix_assignment() {
+    assert_nix!(
+        r#"
+type Wibble {
+  Wibble(wobble: String)
+}
+
+pub fn main() {
+  let tmp = Wibble(wobble: "wibble")
+  case tmp {
+    Wibble(wobble: "w" as wibble <> rest) -> wibble <> rest
+    _ -> panic
+  }
+}
+"#
+    )
+}
+
+#[test]
+fn deeply_nested_string_prefix_assignment() {
+    assert_nix!(
+        r#"
+type Wibble {
+  Wibble(Wobble)
+}
+type Wobble {
+  Wobble(wabble: Wabble)
+}
+type Wabble {
+  Wabble(tuple: #(Int, String))
+}
+
+pub fn main() {
+  let tmp = Wibble(Wobble(Wabble(#(42, "wibble"))))
+  case tmp {
+    Wibble(Wobble(Wabble(#(_int, "w" as wibble <> rest)))) -> wibble <> rest
+    _ -> panic
+  }
+}
+"#
+    )
+}

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__assignments__escaped_variables_in_constants.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__assignments__escaped_variables_in_constants.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/nix/tests/assignments.rs
+expression: "\npub const with = 5\npub const in = with\n"
+---
+----- SOURCE CODE
+
+pub const with = 5
+pub const in = with
+
+
+----- COMPILED NIX
+let with' = 5; in' = with'; in { inherit with' in'; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__assignments__keyword_assignment.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__assignments__keyword_assignment.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/nix/tests/assignments.rs
+expression: "\npub fn main() {\n  let with = 10\n  let in = 50\n  in\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  let with = 10
+  let in = 50
+  in
+}
+
+
+----- COMPILED NIX
+let main = { }: let with' = 10; in' = 50; in in'; in { inherit main; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__assignments__let_assert_nested_string_prefix.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__assignments__let_assert_nested_string_prefix.snap
@@ -1,0 +1,43 @@
+---
+source: compiler-core/src/nix/tests/assignments.rs
+expression: "\ntype Wibble {\n  Wibble(wibble: String)\n}\n\npub fn main() {\n  let assert Wibble(wibble: \"w\" as prefix <> rest) = Wibble(\"wibble\")\n  prefix <> rest\n}\n"
+---
+----- SOURCE CODE
+
+type Wibble {
+  Wibble(wibble: String)
+}
+
+pub fn main() {
+  let assert Wibble(wibble: "w" as prefix <> rest) = Wibble("wibble")
+  prefix <> rest
+}
+
+
+----- COMPILED NIX
+let
+  inherit (builtins.import ./../gleam.nix) strHasPrefix makeError;
+  
+  Wibble = wibble: { __gleamTag = "Wibble"; inherit wibble; };
+  
+  main =
+    { }:
+    let
+      _pat' = (Wibble "wibble");
+      _assert' =
+        if _pat'.__gleamTag != "Wibble" || !(strHasPrefix "w" _pat'.wibble) then
+          builtins.throw
+            (makeError
+              "let_assert"
+              "my/mod"
+              7
+              "main"
+              "Pattern match failed, no pattern matched the value."
+              { value = _pat'; })
+        else null;
+      rest = builtins.seq _assert' (builtins.substring 1 (-1) _pat'.wibble);
+      prefix = builtins.seq _assert' "w";
+    in
+    builtins.seq _assert' (prefix + rest);
+in
+{ inherit main; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__case__deeply_nested_string_prefix_assignment.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__case__deeply_nested_string_prefix_assignment.snap
@@ -1,0 +1,63 @@
+---
+source: compiler-core/src/nix/tests/case.rs
+expression: "\ntype Wibble {\n  Wibble(Wobble)\n}\ntype Wobble {\n  Wobble(wabble: Wabble)\n}\ntype Wabble {\n  Wabble(tuple: #(Int, String))\n}\n\npub fn main() {\n  let tmp = Wibble(Wobble(Wabble(#(42, \"wibble\"))))\n  case tmp {\n    Wibble(Wobble(Wabble(#(_int, \"w\" as wibble <> rest)))) -> wibble <> rest\n    _ -> panic\n  }\n}\n"
+---
+----- SOURCE CODE
+
+type Wibble {
+  Wibble(Wobble)
+}
+type Wobble {
+  Wobble(wabble: Wabble)
+}
+type Wabble {
+  Wabble(tuple: #(Int, String))
+}
+
+pub fn main() {
+  let tmp = Wibble(Wobble(Wabble(#(42, "wibble"))))
+  case tmp {
+    Wibble(Wobble(Wabble(#(_int, "w" as wibble <> rest)))) -> wibble <> rest
+    _ -> panic
+  }
+}
+
+
+----- COMPILED NIX
+let
+  inherit (builtins.import ./../gleam.nix) strHasPrefix makeError;
+  
+  Wibble = x0: { __gleamTag = "Wibble"; _0 = x0; };
+  
+  Wobble = wabble: { __gleamTag = "Wobble"; inherit wabble; };
+  
+  Wabble = tuple: { __gleamTag = "Wabble"; inherit tuple; };
+  
+  main =
+    { }:
+    let
+      tmp = Wibble (Wobble (Wabble [ 42 "wibble" ]));
+    in
+    if
+      tmp.__gleamTag == "Wibble" &&
+      tmp._0.__gleamTag == "Wobble" &&
+      tmp._0.wabble.__gleamTag == "Wabble" &&
+      strHasPrefix "w" (builtins.elemAt tmp._0.wabble.tuple 1)
+    then
+      let
+        rest =
+          (builtins.substring 1 (-1) (builtins.elemAt tmp._0.wabble.tuple 1));
+        wibble = "w";
+      in
+      wibble + rest
+    else
+      builtins.throw
+        (makeError
+          "panic"
+          "my/mod"
+          16
+          "main"
+          "`panic` expression evaluated."
+          { });
+in
+{ inherit main; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__case__nested_string_prefix_assignment.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__case__nested_string_prefix_assignment.snap
@@ -1,0 +1,47 @@
+---
+source: compiler-core/src/nix/tests/case.rs
+expression: "\ntype Wibble {\n  Wibble(wobble: String)\n}\n\npub fn main() {\n  let tmp = Wibble(wobble: \"wibble\")\n  case tmp {\n    Wibble(wobble: \"w\" as wibble <> rest) -> wibble <> rest\n    _ -> panic\n  }\n}\n"
+---
+----- SOURCE CODE
+
+type Wibble {
+  Wibble(wobble: String)
+}
+
+pub fn main() {
+  let tmp = Wibble(wobble: "wibble")
+  case tmp {
+    Wibble(wobble: "w" as wibble <> rest) -> wibble <> rest
+    _ -> panic
+  }
+}
+
+
+----- COMPILED NIX
+let
+  inherit (builtins.import ./../gleam.nix) strHasPrefix makeError;
+  
+  Wibble = wobble: { __gleamTag = "Wibble"; inherit wobble; };
+  
+  main =
+    { }:
+    let
+      tmp = Wibble "wibble";
+    in
+    if tmp.__gleamTag == "Wibble" && strHasPrefix "w" tmp.wobble then
+      let
+        rest = (builtins.substring 1 (-1) tmp.wobble);
+        wibble = "w";
+      in
+      wibble + rest
+    else
+      builtins.throw
+        (makeError
+          "panic"
+          "my/mod"
+          10
+          "main"
+          "`panic` expression evaluated."
+          { });
+in
+{ inherit main; }


### PR DESCRIPTION
Fixes ported:
1. Added some missing JS tests for parity
2. Detect and error when there's `abc.gleam` and `abc.nix` in the same source (sub)directory, as the former would overwrite the latter on build (See https://github.com/gleam-lang/gleam/issues/1562)
3. Fix nested string prefix pattern matching (https://github.com/gleam-lang/gleam/issues/3894)