### PR TITLE
Add deprecation warning for glistix.preview options

### DIFF
--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -242,7 +242,7 @@ pub fn download<Telem: Telemetry>(
     if !config.glistix.preview.local_overrides.is_empty()
         || !config.glistix.preview.hex_patch.is_empty()
     {
-        eprintln!("\n\n============================================================");
+        eprintln!("\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
         cli::print_colourful_prefix(
             "WARNING",
             &glistix_core::error::wrap(
@@ -252,7 +252,7 @@ options in your 'gleam.toml' file. Please use [glistix.preview.patch] instead, a
 See the Glistix handbook for migration instructions: https://glistix.github.io/book/compiler/changelog/v0-7-0.html",
             ),
         );
-        eprintln!("\n============================================================\n\n");
+        eprintln!("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n");
     }
 
     // GLISTIX: Ensure config's patches are consistent

--- a/compiler-cli/src/dependencies.rs
+++ b/compiler-cli/src/dependencies.rs
@@ -239,6 +239,22 @@ pub fn download<Telem: Telemetry>(
     let mut config = crate::config::read(paths.root_config())?;
     let project_name = config.name.clone();
 
+    if !config.glistix.preview.local_overrides.is_empty()
+        || !config.glistix.preview.hex_patch.is_empty()
+    {
+        eprintln!("\n\n============================================================");
+        cli::print_colourful_prefix(
+            "WARNING",
+            &glistix_core::error::wrap(
+                "Using deprecated 'glistix.preview.local-overrides' and 'glistix.preview.hex-patch' \
+options in your 'gleam.toml' file. Please use [glistix.preview.patch] instead, available since Glistix v0.7.0.
+
+See the Glistix handbook for migration instructions: https://glistix.github.io/book/compiler/changelog/v0-7-0.html",
+            ),
+        );
+        eprintln!("\n============================================================\n\n");
+    }
+
     // GLISTIX: Ensure config's patches are consistent
     config
         .glistix


### PR DESCRIPTION
<!-- Thanks for contributing! Make sure to read the "Contributing" section of the README. -->
The following options are now deprecated:

```toml
[glistix.preview]
local-overrides = ["abc"]

[glistix.preview.hex-patch]
pkg = "1.2.3"
```

They should be replaced by `glistix.preview.patch` instead:

```toml
[dependencies]
pkg = "1.2.3" # hex dep goes here
abc = "4.5.6"

[glistix.preview.patch]
abc = { path = "external/abc" } # overrides local deps on 'abc'
pkg = { path = "external/pkg" } # not published to hex
```