### PR TITLE
Export function and module docs on Nix

### DIFF
--- a/compiler-core/src/nix/syntax.rs
+++ b/compiler-core/src/nix/syntax.rs
@@ -159,8 +159,15 @@ pub fn documentation(body: impl IntoIterator<Item = EcoString>) -> Document<'sta
         docvec![
             line(),
             join(
-                body.into_iter()
-                    .map(|doc_line| doc_line.replace("*/", "* /").to_doc()),
+                body.into_iter().map(|doc_line| {
+                    let line = doc_line.replace("*/", "* /");
+
+                    // Allow writing "/// abc" without extra spaces
+                    line.strip_prefix(" ")
+                        .map(EcoString::from)
+                        .unwrap_or(line)
+                        .to_doc()
+                }),
                 line(),
             )
         ]

--- a/compiler-core/src/nix/syntax.rs
+++ b/compiler-core/src/nix/syntax.rs
@@ -2,7 +2,7 @@
 
 use crate::docvec;
 use crate::nix::{Output, INDENT};
-use crate::pretty::{break_, concat, join, nil, Document, Documentable};
+use crate::pretty::{break_, concat, join, line, nil, Document, Documentable};
 use ecow::EcoString;
 use itertools::Itertools;
 use regex::Regex;
@@ -144,6 +144,32 @@ pub fn assignment_line<'a>(name: Document<'a>, value: Document<'a>) -> Document<
         " =",
         docvec![break_("", " "), value, ";"].nest(INDENT).group()
     ]
+}
+
+/// Produces a documentation block:
+///
+/// ```nix
+/// /**
+///   This function does something.
+/// */
+/// ```
+pub fn documentation(body: impl IntoIterator<Item = EcoString>) -> Document<'static> {
+    docvec![
+        "/**",
+        docvec![
+            line(),
+            join(
+                body.into_iter()
+                    .map(|doc_line| doc_line.replace("*/", "* /").to_doc()),
+                line(),
+            )
+        ]
+        .nest(INDENT),
+        line(),
+        "*/",
+        line(),
+    ]
+    .force_break()
 }
 
 /// Generates a Nix expression in the form

--- a/compiler-core/src/nix/tests/documentation.rs
+++ b/compiler-core/src/nix/tests/documentation.rs
@@ -1,0 +1,65 @@
+use crate::assert_nix;
+
+#[test]
+fn function_with_documentation() {
+    assert_nix!(
+        r#"
+/// Function doc!
+pub fn documented() { 1 }"#
+    );
+}
+
+#[test]
+fn record_with_documentation() {
+    assert_nix!(
+        r#"
+/// My record
+type Data {
+  /// Creates a single datum.
+  Datum(field: Int)
+
+  /// Creates empty data.
+  Empty
+}"#
+    );
+}
+
+#[test]
+fn function_with_multiline_documentation() {
+    assert_nix!(
+        r#"
+/// Function doc!
+/// Hello!!
+///
+pub fn documented() { 1 }"#
+    );
+}
+
+#[test]
+fn block_comments_in_documentation_are_escaped() {
+    assert_nix!(
+        r#"
+/// /* hello */
+pub fn documented() { 1 }"#
+    );
+}
+
+#[test]
+fn single_line_module_comment() {
+    assert_nix!(
+        r#"
+//// Hello! This is a single line module comment.
+pub fn main() { 1 }"#
+    );
+}
+
+#[test]
+fn multi_line_module_comment() {
+    assert_nix!(
+        r#"
+//// Hello! This is a multi-
+//// line module comment.
+////
+pub fn main() { 1 }"#
+    );
+}

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__block_comments_in_documentation_are_escaped.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__block_comments_in_documentation_are_escaped.snap
@@ -10,7 +10,7 @@ pub fn documented() { 1 }
 ----- COMPILED NIX
 let
   /**
-     /* hello * /
+    /* hello * /
   */
   documented = { }: 1;
 in

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__block_comments_in_documentation_are_escaped.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__block_comments_in_documentation_are_escaped.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/nix/tests/documentation.rs
+expression: "\n/// /* hello */\npub fn documented() { 1 }"
+---
+----- SOURCE CODE
+
+/// /* hello */
+pub fn documented() { 1 }
+
+----- COMPILED NIX
+let
+  /**
+     /* hello * /
+  */
+  documented = { }: 1;
+in
+{ inherit documented; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__function_with_documentation.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__function_with_documentation.snap
@@ -10,7 +10,7 @@ pub fn documented() { 1 }
 ----- COMPILED NIX
 let
   /**
-     Function doc!
+    Function doc!
   */
   documented = { }: 1;
 in

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__function_with_documentation.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__function_with_documentation.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/nix/tests/documentation.rs
+expression: "\n/// Function doc!\npub fn documented() { 1 }"
+---
+----- SOURCE CODE
+
+/// Function doc!
+pub fn documented() { 1 }
+
+----- COMPILED NIX
+let
+  /**
+     Function doc!
+  */
+  documented = { }: 1;
+in
+{ inherit documented; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__function_with_multiline_documentation.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__function_with_multiline_documentation.snap
@@ -12,8 +12,8 @@ pub fn documented() { 1 }
 ----- COMPILED NIX
 let
   /**
-     Function doc!
-     Hello!!
+    Function doc!
+    Hello!!
     
   */
   documented = { }: 1;

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__function_with_multiline_documentation.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__function_with_multiline_documentation.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/nix/tests/documentation.rs
+expression: "\n/// Function doc!\n/// Hello!!\n///\npub fn documented() { 1 }"
+---
+----- SOURCE CODE
+
+/// Function doc!
+/// Hello!!
+///
+pub fn documented() { 1 }
+
+----- COMPILED NIX
+let
+  /**
+     Function doc!
+     Hello!!
+    
+  */
+  documented = { }: 1;
+in
+{ inherit documented; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__multi_line_module_comment.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__multi_line_module_comment.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/nix/tests/documentation.rs
+expression: "\n//// Hello! This is a multi-\n//// line module comment.\n////\npub fn main() { 1 }"
+---
+----- SOURCE CODE
+
+//// Hello! This is a multi-
+//// line module comment.
+////
+pub fn main() { 1 }
+
+----- COMPILED NIX
+/**
+   Hello! This is a multi-
+   line module comment.
+  
+*/
+let main = { }: 1; in { inherit main; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__multi_line_module_comment.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__multi_line_module_comment.snap
@@ -11,8 +11,8 @@ pub fn main() { 1 }
 
 ----- COMPILED NIX
 /**
-   Hello! This is a multi-
-   line module comment.
+  Hello! This is a multi-
+  line module comment.
   
 */
 let main = { }: 1; in { inherit main; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__record_with_documentation.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__record_with_documentation.snap
@@ -16,12 +16,12 @@ type Data {
 ----- COMPILED NIX
 let
   /**
-     Creates a single datum.
+    Creates a single datum.
   */
   Datum = field: { __gleamTag = "Datum"; inherit field; };
   
   /**
-     Creates empty data.
+    Creates empty data.
   */
   Empty = { __gleamTag = "Empty"; };
 in

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__record_with_documentation.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__record_with_documentation.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/nix/tests/documentation.rs
+expression: "\n/// My record\ntype Data {\n  /// Creates a single datum.\n  Datum(field: Int)\n\n  /// Creates empty data.\n  Empty\n}"
+---
+----- SOURCE CODE
+
+/// My record
+type Data {
+  /// Creates a single datum.
+  Datum(field: Int)
+
+  /// Creates empty data.
+  Empty
+}
+
+----- COMPILED NIX
+let
+  /**
+     Creates a single datum.
+  */
+  Datum = field: { __gleamTag = "Datum"; inherit field; };
+  
+  /**
+     Creates empty data.
+  */
+  Empty = { __gleamTag = "Empty"; };
+in
+{ }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__single_line_module_comment.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__single_line_module_comment.snap
@@ -1,0 +1,14 @@
+---
+source: compiler-core/src/nix/tests/documentation.rs
+expression: "\n//// Hello! This is a single line module comment.\npub fn main() { 1 }"
+---
+----- SOURCE CODE
+
+//// Hello! This is a single line module comment.
+pub fn main() { 1 }
+
+----- COMPILED NIX
+/**
+   Hello! This is a single line module comment.
+*/
+let main = { }: 1; in { inherit main; }

--- a/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__single_line_module_comment.snap
+++ b/compiler-core/src/nix/tests/snapshots/glistix_core__nix__tests__documentation__single_line_module_comment.snap
@@ -9,6 +9,6 @@ pub fn main() { 1 }
 
 ----- COMPILED NIX
 /**
-   Hello! This is a single line module comment.
+  Hello! This is a single line module comment.
 */
 let main = { }: 1; in { inherit main; }


### PR DESCRIPTION
Closes #14

Inspired by https://github.com/gleam-lang/gleam/pull/4147

The code below:
```gleam
/// Function doc!
pub fn documented() { 1 }
```

Produces:
```nix
let
  /**
     Function doc!
  */
  documented = { }: 1;
in
{ inherit documented; }
```

Which, since Nix 2.24, can be read as follows from the Nix REPL:

```nix
nix-repl> :doc documented                                                                                                                               
  Function documented                                                                                                                                     
      … defined at dir/abc.nix:5:16                                                                                                                
                                                                                                                                                          
      Function doc!                                                                                                                                       
                                                                                                                                                          
  ```